### PR TITLE
Upgrade to Hibernate 5.2

### DIFF
--- a/gilead-hibernate/src/net/sf/gilead/core/hibernate/HibernateUtil.java
+++ b/gilead-hibernate/src/net/sf/gilead/core/hibernate/HibernateUtil.java
@@ -1581,8 +1581,8 @@ public class HibernateUtil implements PersistenceUtil {
      */
     private List<String> getEntityNamesFor(Class<?> clazz) {
         List<String> entityNames = new ArrayList<String>();
-        Map<String, ClassMetadata> allMetadata = _sessionFactory.getAllClassMetadata();
-        for (ClassMetadata classMetadata : allMetadata.values()) {
+        Map<String, EntityPersister> allMetadata = _sessionFactory.getMetamodel().entityPersisters();
+        for (EntityPersister classMetadata : allMetadata.values()) {
             if (clazz.equals(classMetadata.getMappedClass())) {
                 entityNames.add(classMetadata.getEntityName());
             }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<version.com.google.gwt>2.6.1</version.com.google.gwt>
 		<version.javax.javaee-api>7.0</version.javax.javaee-api>
 		<version.net.sf.beanlib>7.1.0</version.net.sf.beanlib>
-		<version.org.hibernate>5.0.10.Final</version.org.hibernate>
+		<version.org.hibernate>5.2.11.Final</version.org.hibernate>
 		<version.org.slf4j>1.7.7</version.org.slf4j>
 		<version.org.wildfly>10.1.0.Final</version.org.wildfly>
 


### PR DESCRIPTION
When using Gilead with Hibernate 5.2, an UnsupportedOperationException is thrown. This change fixes this and prevents `org.hibernate.SessionFactory.getAllClassMetadata is no longer supported`